### PR TITLE
Added proposal_name secondary index

### DIFF
--- a/include/forum.hpp
+++ b/include/forum.hpp
@@ -102,10 +102,12 @@ class forum : public eosio::contract {
             time                   updated_at;
 
             auto primary_key() const { return id; }
+            uint64_t by_proposal() const { return proposal_name; }
             uint128_t by_vote_key() const { return forum::compute_vote_key(proposal_name, voter); }
         };
         typedef eosio::multi_index<
             N(vote), voterow,
+            indexed_by<N(proposal), const_mem_fun<voterow, uint64_t, &voterow::by_proposal>>,
             indexed_by<N(votekey), const_mem_fun<voterow, uint128_t, &voterow::by_vote_key>>
         > votes;
 


### PR DESCRIPTION
This addition makes it "much" easier to retrieve the all the votes for a given proposal.

Instead of having to know the exact key information, one can now use a simpler name value. However, the upper bound value must still be name + 1 since the upper value is exclusive and makes it hard to query just for a given one.

**DO NOT MERGE** For review only right now. Needs to get more info about RAM usage of secondary indexes.